### PR TITLE
docs: path reference

### DIFF
--- a/docs/nixos-firehol-docs.nix
+++ b/docs/nixos-firehol-docs.nix
@@ -1,10 +1,6 @@
 { pkgs, ...}:
 let
-  url = "https://github.com/TinHead/nixos-firehol.git";
-  src =  builtins.fetchGit {
-    inherit url;
-    ref = "main";
-  };
+  src =  ../.;
   pkg = pkgs.writeText "nixos-firehol.nix"
     (builtins.replaceStrings
       ["lib.mdDoc "]
@@ -19,5 +15,4 @@ in
     ---
     - [NixOS-FireHOL](./nixos-firehol.md)
   '';
-#  about.sources = "- [NixOS-FireHOL](https://github.com/TinHead/nixos-firehol)";
 }


### PR DESCRIPTION
There is an issue in your current path scheme, it resolves online code, that means your content is always one push behind.

Lets try relative path instead.